### PR TITLE
Optimized BLE connection by adding ringbuffer

### DIFF
--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/CHANGELOG.md
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.1] - 2023-XX-XX
+
+### Added
+
+- 
+
+### Fixed
+
+- BLE Package loss by implementing buffering on the nRF52. As a consequence, an increased power consumption (+2-5 mW and more) can be observed in noisy RF environment.
+
+### Changed
+
+- Moved the main macro definitions to `us_defines.h`
+
+### Removed
+
+- Cleaned the old (not used) code

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/main.c
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/main.c
@@ -52,22 +52,11 @@
 #include "us_ble.h"
 #include "us_defines.h"
 
-
-// Define GPIOs
-#define LED_NRF52 23
-#define PIN_DATA_READY 29
-#define PIN_BLE_CONN_READY 25
-
 // Buffers to store US data
-ArrayList_type m_rx_buf_1[NUMBER_OF_XFERS] = {0};
-ArrayList_type m_rx_buf_2[NUMBER_OF_XFERS] = {0};
 ArrayList_type m_rx_buf[NUMBER_OF_XFERS*MAX_BUFFER_NUMBER_OF_US_FRAMES] = {0};
 
 // Buffer to store commands from python
 ArrayList_type m_tx_buf_1[NUMBER_OF_XFERS] = {0};
-
-// Flag to implement double buffering
-volatile bool flag_use_buf_1 = true;
 
 // Timer and counter to control SPI transactions
 extern nrf_drv_timer_t timer_timer;

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/pca10040/s132/ses/US_probe_nRF52_firmware.emSession
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/pca10040/s132/ses/US_probe_nRF52_firmware.emSession
@@ -22,6 +22,8 @@
   <ProjectSessionItem path="US_probe_nRF52_firmware"/>
   <ProjectSessionItem path="US_probe_nRF52_firmware;US_probe_nRF52_firmware"/>
   <ProjectSessionItem path="US_probe_nRF52_firmware;US_probe_nRF52_firmware;Application"/>
+  <ProjectSessionItem path="US_probe_nRF52_firmware;US_probe_nRF52_firmware;nRF_BLE_Services"/>
+  <ProjectSessionItem path="US_probe_nRF52_firmware;US_probe_nRF52_firmware;nRF_Drivers"/>
   <ProjectSessionItem path="US_probe_nRF52_firmware;US_probe_nRF52_firmware;nRF_Libraries"/>
  </Project>
  <Register1>
@@ -55,13 +57,19 @@
   <Watches active="0" update="Never"/>
  </Watch4>
  <Files>
-  <SessionOpenFile windowGroup="DockEditLeft" x="55" y="38" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_ble.c" selected="1" top="25" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="15" y="77" useTextEdit="1" openedFrom="C:/Users/Sergey/Downloads/WULPUS/ultra-low-power-ultrasound-probe/dev_nrf52/nRF5_SDK_17.1.0/examples/ble_peripheral/US_probe_nRF52_firmware/us_spi.c" useBinaryEdit="0" left="0" path="../../../main.c" selected="0" top="5" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="33" y="12" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_ble.h" selected="0" top="0" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="15" y="23" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_spi.h" selected="0" top="0" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="24" y="152" useTextEdit="1" openedFrom="C:/Users/Sergey/Downloads/WULPUS/ultra-low-power-ultrasound-probe/dev_nrf52/nRF5_SDK_17.1.0/examples/ble_peripheral/US_probe_nRF52_firmware/us_spi.h" useBinaryEdit="0" left="0" path="../../../us_spi.c" selected="0" top="0" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="0" y="0" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_defines.h" selected="0" top="0" codecName="Default"/>
-  <SessionOpenFile windowGroup="DockEditLeft" x="0" y="99" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../../../../components/libraries/util/app_error_weak.c" selected="0" top="65" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="43" y="193" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/us_spi.c" useBinaryEdit="0" left="0" path="../../../us_ble.c" selected="0" top="157" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="10" y="224" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/us_ble.c" useBinaryEdit="0" left="0" path="../../../main.c" selected="0" top="184" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="28" y="31" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_ble.h" selected="0" top="0" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="3" y="23" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../us_spi.h" selected="0" top="0" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="0" y="184" useTextEdit="1" openedFrom="C:/Users/Sergey/Downloads/WULPUS/ultra-low-power-ultrasound-probe/dev_nrf52/nRF5_SDK_17.1.0/examples/ble_peripheral/US_probe_nRF52_firmware/us_spi.h" useBinaryEdit="0" left="0" path="../../../us_spi.c" selected="1" top="150" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="51" y="22" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/main.c" useBinaryEdit="0" left="0" path="../../../us_defines.h" selected="0" top="9" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="0" y="110" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../../../../components/libraries/util/app_error_weak.c" selected="0" top="50" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="1" y="244" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/us_ble.c" useBinaryEdit="0" left="0" path="../../../../../../components/ble/ble_services/ble_nus/ble_nus.c" selected="0" top="221" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="11" y="486" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../../../../../../modules/nrfx/drivers/src/nrfx_spim.c" selected="0" top="464" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="32" y="98" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/us_ble.c" useBinaryEdit="0" left="0" path="../../../../../../integration/nrfx/legacy/nrf_drv_gpiote.h" selected="0" top="73" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="40" y="11545" useTextEdit="1" openedFrom="" useBinaryEdit="0" left="0" path="../config/sdk_config.h" selected="0" top="11527" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="18" y="147" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/examples/ble_peripheral/US_probe_nRF52_firmware/us_spi.c" useBinaryEdit="0" left="0" path="../../../../../../components/libraries/util/app_error.h" selected="0" top="137" codecName="Default"/>
+  <SessionOpenFile windowGroup="DockEditLeft" x="5" y="46" useTextEdit="1" openedFrom="C:/Users/s-fre/Downloads/nRF5_SDK_17.1.0_ddde560/components/libraries/util/app_error.h" useBinaryEdit="0" left="0" path="../../../../../../components/libraries/util/app_error_handler_gcc.c" selected="0" top="0" codecName="Default"/>
  </Files>
  <ARMCrossStudioWindow activeProject="US_probe_nRF52_firmware" fileDialogDefaultFilter="*.c" autoConnectTarget="J-Link" buildConfiguration="Debug" sessionSettings="" debugSearchFileMap="" fileDialogInitialDirectory="" debugSearchPath="" autoConnectCapabilities="3711"/>
 </session>

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.c
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.c
@@ -77,7 +77,6 @@
 
 #define APP_BLE_CONN_CFG_TAG            1                                           /**< A tag identifying the SoftDevice BLE configuration. */
 
-#define DEVICE_NAME                     "WULPUS_PROBE_0"                            /**< Name of device. Will be included in the advertising data. */
 #define NUS_SERVICE_UUID_TYPE           BLE_UUID_TYPE_VENDOR_BEGIN                  /**< UUID type for the Nordic UART Service (vendor specific). */
 
 #define APP_BLE_OBSERVER_PRIO           3                                           /**< Application's BLE observer priority. You shouldn't need to modify this value. */

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.c
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.c
@@ -77,7 +77,7 @@
 
 #define APP_BLE_CONN_CFG_TAG            1                                           /**< A tag identifying the SoftDevice BLE configuration. */
 
-#define DEVICE_NAME                     "WULPUS_PROBE_3"                            /**< Name of device. Will be included in the advertising data. */
+#define DEVICE_NAME                     "WULPUS_PROBE_0"                            /**< Name of device. Will be included in the advertising data. */
 #define NUS_SERVICE_UUID_TYPE           BLE_UUID_TYPE_VENDOR_BEGIN                  /**< UUID type for the Nordic UART Service (vendor specific). */
 
 #define APP_BLE_OBSERVER_PRIO           3                                           /**< Application's BLE observer priority. You shouldn't need to modify this value. */
@@ -90,16 +90,18 @@
 #define MAX_CONN_INTERVAL               MSEC_TO_UNITS(7.5, UNIT_1_25_MS)             /**< Maximum acceptable connection interval (75 ms), Connection interval uses 1.25 ms units. */
 #define SLAVE_LATENCY                   5                                           /**< Slave latency. */
 #define CONN_SUP_TIMEOUT                MSEC_TO_UNITS(4000, UNIT_10_MS)             /**< Connection supervisory timeout (4 seconds), Supervision Timeout uses 10 ms units. */
-#define FIRST_CONN_PARAMS_UPDATE_DELAY  APP_TIMER_TICKS(400)                       /**< Time from initiating event (connect or start of notification) to first time sd_ble_gap_conn_param_update is called (1000 ms). */
-#define NEXT_CONN_PARAMS_UPDATE_DELAY   APP_TIMER_TICKS(600)                   /**< Time between each call to sd_ble_gap_conn_param_update after the first call (10 h). */
+#define FIRST_CONN_PARAMS_UPDATE_DELAY  APP_TIMER_TICKS(400)                        /**< Time from initiating event (connect or start of notification) to first time sd_ble_gap_conn_param_update is called (1000 ms). */
+#define NEXT_CONN_PARAMS_UPDATE_DELAY   APP_TIMER_TICKS(600)                        /**< Time between each call to sd_ble_gap_conn_param_update after the first call (10 h). */
 #define MAX_CONN_PARAMS_UPDATE_COUNT    3                                           /**< Number of attempts before giving up the connection parameter negotiation. */
 
 #define DEAD_BEEF                       0xDEADBEEF                                  /**< Value used as error code on stack dump, can be used to identify stack location on stack unwind. */
 
 extern ArrayList_type m_tx_buf_1[NUMBER_OF_XFERS];
+extern ArrayList_type m_rx_buf[NUMBER_OF_XFERS*MAX_BUFFER_NUMBER_OF_US_FRAMES];
 
 extern volatile bool ble_connected;
 extern volatile bool msp_conf_received;
+extern int BLE_packet_ready;
 
 void sleep_mode_enter(void);
 
@@ -115,7 +117,9 @@ static ble_uuid_t m_adv_uuids[]          =                                      
     {BLE_UUID_NUS_SERVICE, NUS_SERVICE_UUID_TYPE}
 };
 
-
+int buffer_content = 0;
+int buffer_counter = 0;
+int current_buffer = 0;
 
 /**@brief Function for assert macro callback.
  *
@@ -192,8 +196,13 @@ static void nus_data_handler(ble_nus_evt_t * p_evt)
         // Copy received command from python to the SPI transmit buffer
         memcpy(m_tx_buf_1, p_evt->params.rx_data.p_data, p_evt->params.rx_data.length);
         msp_conf_received = true;
-    }
 
+        // Clear the BLE buffers to send US data with the received configuration
+        current_buffer = 0;
+        buffer_counter = 0;
+        buffer_content = 0;
+        BLE_packet_ready = 0;
+    }
 }
 /**@snippet [Handling the data received over BLE] */
 
@@ -521,28 +530,46 @@ void advertising_start(void)
  */
 void send_packet(uint8_t* start_address, uint16_t length)
 {
-    uint32_t err_code;
-    uint16_t attemt_nr;
-    attemt_nr = 0;
-
-    // Send the BLE packet
-    // Stop trying to send it if:
-    //    1) It was sent (NRF_ERROR_RESOURCES==false)
-    //    2) attemt_nr is too high -> No more time to try sending, have to drop the
-    //       packet to keep real time operation
-    do
-    {
-        err_code = ble_nus_data_send(&m_nus, start_address, &length, m_conn_handle);
-        attemt_nr++;
-        if ((err_code != NRF_ERROR_INVALID_STATE) &&
-            (err_code != NRF_ERROR_RESOURCES) &&
-            (err_code != NRF_ERROR_NOT_FOUND))
+        uint32_t err_code;
+        do
         {
-            // would trap the code in case of overloaded BLE
-            // Left here for future debugging
-            //APP_ERROR_CHECK(err_code);
-        }
-    } while ((err_code == NRF_ERROR_RESOURCES) && attemt_nr<100);
+            err_code = ble_nus_data_send(&m_nus, start_address, &length, m_conn_handle);
+            if ((err_code != NRF_ERROR_INVALID_STATE) &&
+                (err_code != NRF_ERROR_RESOURCES) &&
+                (err_code != NRF_ERROR_NOT_FOUND))
+            {
+                APP_ERROR_CHECK(err_code);
+            }
+        } while (err_code==NRF_ERROR_RESOURCES); //while (err_code==NRF_ERROR_RESOURCES && msp_conf_received==false);  
+}
+
+
+/**
+ * Function to send all the US frame that are currently buffered in the m_rx_buf ringbuffer
+ */
+void send_pending_frames()
+{
+
+  if(ble_connected)
+  {
+      if (BLE_packet_ready==1)
+      { 
+          
+          while(current_buffer !=  buffer_counter)
+          {
+            // Send all 4 BLE packets that make up one US frame
+            send_packet(&m_rx_buf[0+current_buffer*NUMBER_OF_XFERS].buffer[0], BYTES_PR_XFER_RX+1);
+            send_packet(&m_rx_buf[1+current_buffer*NUMBER_OF_XFERS].buffer[0], BYTES_PR_XFER_RX);
+            send_packet(&m_rx_buf[2+current_buffer*NUMBER_OF_XFERS].buffer[0], BYTES_PR_XFER_RX);
+            send_packet(&m_rx_buf[3+current_buffer*NUMBER_OF_XFERS].buffer[0], BYTES_PR_XFER_RX);
+            current_buffer++;
+            buffer_content--;
+            if(current_buffer == MAX_BUFFER_NUMBER_OF_US_FRAMES)
+              current_buffer = 0;
+          }
+          BLE_packet_ready=0;
+      }
+  }
 }
 
 /** 

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.h
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_ble.h
@@ -26,6 +26,10 @@
      */
     void us_ble_init(void);
 
+    /**
+     * Function to send all the US frame that are currently buffered in the m_rx_buf ringbuffer
+     */
+    void send_pending_frames(void);
 
     /**
      * Function to start BLE advertising, called from main

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_defines.h
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_defines.h
@@ -27,6 +27,9 @@
 #ifndef US_DEFINES_H
 #define US_DEFINES_H
 
+    // Name of device. Will be included in the advertising data.
+    #define DEVICE_NAME  "WULPUS_PROBE_0"
+
     // Number of bytes per transfer to send to SPI slave
     #define BYTES_PR_XFER_TX   201
     // Number of bytes per transfer to receive from SPI slave
@@ -38,6 +41,18 @@
 
     // Max number of US frames to buffer
     #define MAX_BUFFER_NUMBER_OF_US_FRAMES 35
+
+    // Define GPIOs
+    #define LED_NRF52 23
+    #define PIN_DATA_READY 29
+    #define PIN_BLE_CONN_READY 25
+
+    // Define SPI pins
+    #define PIN_SPI_SS 7
+    #define PIN_SPI_MISO 9
+    #define PIN_SPI_MOSI 10
+    #define PIN_SPI_SCK 8
+
 
     typedef struct ArrayList
     {

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_defines.h
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_defines.h
@@ -36,7 +36,8 @@
     #define NUMBER_OF_XFERS 4
     //#define DELAY_BETWEEN_TRANSFERS 1
 
-
+    // Max number of US frames to buffer
+    #define MAX_BUFFER_NUMBER_OF_US_FRAMES 35
 
     typedef struct ArrayList
     {

--- a/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_spi.c
+++ b/fw/nrf52/ble_peripheral/US_probe_nRF52_firmware/us_spi.c
@@ -58,6 +58,7 @@
 #define PIN_SPI_MOSI 10
 #define PIN_SPI_SCK 8
 
+extern ArrayList_type m_rx_buf[NUMBER_OF_XFERS*MAX_BUFFER_NUMBER_OF_US_FRAMES];
 extern ArrayList_type m_rx_buf_1[NUMBER_OF_XFERS];
 extern ArrayList_type m_rx_buf_2[NUMBER_OF_XFERS];
 extern ArrayList_type m_tx_buf_1[NUMBER_OF_XFERS];
@@ -68,8 +69,15 @@ extern bool flag_use_buf_1;
 // Flag to know if BLE is connected (-> and therefore US measurements can start)
 extern volatile bool ble_connected;
 
+extern volatile bool msp_conf_received;
+
+extern int buffer_content;
+extern int buffer_counter;
+
 // Function to send one BLE packet
 void send_packet(uint8_t* start_address, uint16_t length);
+void send_packet(uint8_t* start_address, uint16_t length);
+
 
 //Time(in microseconds) between consecutive compare events. (257 us is absolute min for 255Bytes at 8Mbps)
 uint32_t time_us = 300; 
@@ -89,7 +97,7 @@ uint32_t timer0_timeout_cc0_evt_addr;
 uint32_t counter1_count_task_addr;
 uint32_t counter1_cc0_evt_addr;
 
-
+int BLE_packet_ready = 0;
 
 void spi_event_handler(nrf_drv_spi_evt_t const * p_event,
                        void *                    p_context)
@@ -119,7 +127,7 @@ void spi_init()
     APP_ERROR_CHECK(err_code);
     
     // Setting up an SPI transfer using EasyDMA
-    nrf_drv_spi_xfer_desc_t xfer = NRF_DRV_SPI_XFER_TRX((uint8_t *)m_tx_buf_1, BYTES_PR_XFER_TX, (uint8_t *)m_rx_buf_1, BYTES_PR_XFER_RX);
+    nrf_drv_spi_xfer_desc_t xfer = NRF_DRV_SPI_XFER_TRX((uint8_t *)m_tx_buf_1, BYTES_PR_XFER_TX, (uint8_t *)m_rx_buf, BYTES_PR_XFER_RX);
     
     uint32_t flags = NRF_DRV_SPI_FLAG_HOLD_XFER           |
                      NRF_DRV_SPI_FLAG_RX_POSTINC          |
@@ -151,6 +159,45 @@ void timer_timeout_event_handler(nrf_timer_event_t event_type, void* p_context)
  *
  */
 void counter_cc0_event_handler(nrf_timer_event_t event_type, void* p_context)
+{
+    // Stop timers and hence, stop SPI transfers.
+    nrf_drv_timer_disable(&timer_timer);
+    nrf_drv_timer_disable(&timer_counter);
+    
+    buffer_content++;
+
+    if(buffer_content>3)
+    {
+        // Just for testing
+        nrf_drv_gpiote_out_set(23);
+    }
+    else
+    {
+        nrf_drv_gpiote_out_clear(23);
+    }
+
+    
+    if(buffer_content>MAX_BUFFER_NUMBER_OF_US_FRAMES-1)
+    {
+        // Buffer overflow error handling 
+        //APP_ERROR_CHECK(1);
+    }
+
+    buffer_counter++;
+    if(buffer_counter == MAX_BUFFER_NUMBER_OF_US_FRAMES)
+        buffer_counter = 0;
+
+    BLE_packet_ready = 1;
+    //msp_conf_received = false;
+    
+    // Relay the received SPI data to the BLE dongle
+    uint32_t err_code;
+    uint16_t length;
+
+    length = BYTES_PR_XFER_RX;
+
+}
+void counter_cc0_event_handler_old(nrf_timer_event_t event_type, void* p_context)
 {
     // Stop timers and hence, stop SPI transfers.
     nrf_drv_timer_disable(&timer_timer);


### PR DESCRIPTION
Changes:
- Replaced BLE double buffering with a ringbuffer to improve the BLE reliability
- Added a "warning" LED that lights up when there are more than three US frames in the ringbuffer
- Size of ringbuffer can be easily changed by adjusting #define MAX_BUFFER_NUMBER_OF_US_FRAMES 35 

To be tested:
- Current consumption of the new implementation